### PR TITLE
Allow metrics for all labeled examples

### DIFF
--- a/models/losses.py
+++ b/models/losses.py
@@ -66,8 +66,8 @@ class ACTLossHead(nn.Module):
             is_correct = mask & (torch.argmax(outputs["logits"], dim=-1) == labels)
             seq_is_correct = is_correct.sum(-1) == loss_counts
             
-            # Metrics (halted)
-            valid_metrics = new_carry.halted & (loss_counts > 0)
+            # Metrics include any example with labels regardless of halting
+            valid_metrics = loss_counts > 0
             metrics = {
                 "count": valid_metrics.sum(),
                 


### PR DESCRIPTION
## Summary
- ensure ACTLossHead metrics include all sequences with labels, ignoring halting flag

## Testing
- ✅ `python - <<'PY'
import torch
from dataclasses import dataclass
from models.losses import ACTLossHead
@dataclass
class Carry:
    halted: torch.Tensor
    steps: torch.Tensor
    current_data: dict
class DummyModel(torch.nn.Module):
    def forward(self, **model_kwargs):
        labels = model_kwargs['labels']
        batch_size, seq_len = labels.shape
        logits = torch.zeros(batch_size, seq_len, 3)
        for i in range(batch_size):
            for j in range(seq_len):
                logits[i,j,labels[i,j]] = 1.0
        outputs={'logits':logits, 'q_halt_logits':torch.zeros(batch_size)}
        carry = Carry(halted=torch.zeros(batch_size,dtype=torch.bool),
                      steps=torch.zeros(batch_size,dtype=torch.int32),
                      current_data={'labels': labels})
        return carry, outputs
model = DummyModel()
loss_head = ACTLossHead(model, loss_type='stablemax_cross_entropy')
labels = torch.tensor([[1,2]])
new_carry, loss, metrics, detached_outputs, all_finish = loss_head(return_keys=[], labels=labels)
print(metrics)
PY`
- ⚠️ `python pretrain.py ...` *(missing `adam_atan2_backend` dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68bc4cf176cc832b8139bd5e758db5ce